### PR TITLE
Add newsletter signup with listmonk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.dev.vars
 
 # macOS-specific files
 .DS_Store

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -59,6 +59,32 @@ const cols = [
           Sovereign AI infrastructure. Build, deploy, govern, and operate AI on
           infrastructure you control.
         </p>
+
+        <form class="ft__nl" id="nl-form">
+          <label class="ft__nl-label" for="nl-email">Get product updates</label>
+          <div class="ft__nl-row">
+            <input
+              class="ft__nl-input"
+              id="nl-email"
+              type="email"
+              name="email"
+              placeholder="you@company.com"
+              required
+              aria-label="Email address"
+            />
+            <input
+              class="ft__nl-hp"
+              type="text"
+              name="company"
+              tabindex="-1"
+              autocomplete="off"
+              aria-hidden="true"
+            />
+            <button class="ft__nl-btn" type="submit">Subscribe</button>
+          </div>
+          <p class="ft__nl-status" id="nl-status" role="status"></p>
+        </form>
+
         <div class="ft__meta">Belgrade, Serbia · Apache 2.0</div>
       </div>
       <div class="ft__cols">
@@ -90,3 +116,45 @@ const cols = [
     </div>
   </div>
 </footer>
+
+<script>
+  const form = document.getElementById("nl-form") as HTMLFormElement | null;
+  form?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const status = document.getElementById("nl-status");
+    const submitBtn = form.querySelector<HTMLButtonElement>(".ft__nl-btn");
+    if (!status || !submitBtn) return;
+
+    const email = (
+      form.elements.namedItem("email") as HTMLInputElement
+    ).value.trim();
+    const company = (form.elements.namedItem("company") as HTMLInputElement)
+      .value;
+
+    status.textContent = "";
+    status.classList.remove("is-error");
+    submitBtn.disabled = true;
+    const originalLabel = submitBtn.textContent;
+    submitBtn.textContent = "Subscribing…";
+
+    try {
+      const res = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, company }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Something went wrong.");
+
+      form.reset();
+      status.textContent = "You're subscribed — check your inbox.";
+      submitBtn.textContent = originalLabel;
+    } catch (err) {
+      status.textContent =
+        err instanceof Error ? err.message : "Something went wrong.";
+      status.classList.add("is-error");
+      submitBtn.disabled = false;
+      submitBtn.textContent = originalLabel;
+    }
+  });
+</script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,20 @@
+import type { Runtime } from "@astrojs/cloudflare";
+
+type CloudflareEnv = {
+  LISTMONK_URL: string;
+  LISTMONK_LIST_UUID: string;
+  LISTMONK_LIST_ID: string;
+  LISTMONK_WELCOME_TEMPLATE_ID: string;
+  LISTMONK_FROM_EMAIL: string;
+  LISTMONK_TX_API_USER: string;
+  LISTMONK_TX_API_TOKEN: string;
+};
+
+declare global {
+  namespace App {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- declaration merging requires an empty extends body
+    interface Locals extends Runtime<CloudflareEnv> {}
+  }
+}
+
+export {};

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime.env;
+
+  let body: { email?: unknown; company?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid request." }, 400);
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  // Honeypot: real users never fill this hidden field.
+  if (typeof body.company === "string" && body.company.trim() !== "") {
+    return json({ ok: true });
+  }
+
+  if (!EMAIL_RE.test(email)) {
+    return json({ error: "Enter a valid email address." }, 400);
+  }
+
+  let subscribeRes: Response;
+  try {
+    subscribeRes = await fetch(`${env.LISTMONK_URL}/api/public/subscription`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        name: "",
+        list_uuids: [env.LISTMONK_LIST_UUID],
+      }),
+    });
+  } catch {
+    return json({ error: "Could not reach the subscription service." }, 502);
+  }
+
+  if (!subscribeRes.ok) {
+    let message = "Could not subscribe right now.";
+    try {
+      const errBody = await subscribeRes.json();
+      if (errBody && typeof errBody.message === "string")
+        message = errBody.message;
+    } catch {
+      // Fall back to the generic message above.
+    }
+    return json({ error: message }, subscribeRes.status === 400 ? 400 : 502);
+  }
+
+  locals.runtime.ctx.waitUntil(sendWelcomeEmail(email, env));
+
+  return json({ ok: true });
+};
+
+// Best-effort: a failed welcome email shouldn't fail the subscription itself.
+async function sendWelcomeEmail(
+  email: string,
+  env: App.Locals["runtime"]["env"],
+) {
+  try {
+    const res = await fetch(`${env.LISTMONK_URL}/api/tx`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Basic " +
+          btoa(`${env.LISTMONK_TX_API_USER}:${env.LISTMONK_TX_API_TOKEN}`),
+      },
+      body: JSON.stringify({
+        subscriber_email: email,
+        template_id: Number(env.LISTMONK_WELCOME_TEMPLATE_ID),
+        from_email: env.LISTMONK_FROM_EMAIL,
+      }),
+    });
+    if (!res.ok) {
+      console.error("welcome email failed", res.status, await res.text());
+    }
+  } catch (err) {
+    console.error("welcome email error", err);
+  }
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/unsubscribe.astro
+++ b/src/pages/unsubscribe.astro
@@ -1,0 +1,127 @@
+---
+export const prerender = false;
+
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+
+const env = Astro.locals.runtime.env;
+const email = Astro.url.searchParams.get("email")?.trim() ?? "";
+
+let state: "invalid" | "done" | "error" = "invalid";
+
+if (email) {
+  state = "error";
+  try {
+    const searchRes = await fetch(
+      `${env.LISTMONK_URL}/api/subscribers?search=${encodeURIComponent(email)}`,
+      {
+        headers: {
+          Authorization:
+            "Basic " +
+            btoa(`${env.LISTMONK_TX_API_USER}:${env.LISTMONK_TX_API_TOKEN}`),
+        },
+      },
+    );
+    if (!searchRes.ok) {
+      console.error(
+        "unsubscribe search failed",
+        searchRes.status,
+        await searchRes.text(),
+      );
+    } else {
+      const searchData: { data: { results: { id: number; email: string }[] } } =
+        await searchRes.json();
+      const match = searchData.data.results.find(
+        (r) => r.email.toLowerCase() === email.toLowerCase(),
+      );
+
+      // No match means the address is already off the list (or never was on
+      // it) — treat that as success too, since the end state is the same.
+      if (!match) {
+        state = "done";
+      } else {
+        const unsubRes = await fetch(
+          `${env.LISTMONK_URL}/api/subscribers/lists`,
+          {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization:
+                "Basic " +
+                btoa(
+                  `${env.LISTMONK_TX_API_USER}:${env.LISTMONK_TX_API_TOKEN}`,
+                ),
+            },
+            body: JSON.stringify({
+              ids: [match.id],
+              action: "unsubscribe",
+              target_list_ids: [Number(env.LISTMONK_LIST_ID)],
+            }),
+          },
+        );
+        if (!unsubRes.ok) {
+          console.error(
+            "unsubscribe put failed",
+            unsubRes.status,
+            await unsubRes.text(),
+          );
+        }
+        state = unsubRes.ok ? "done" : "error";
+      }
+    }
+  } catch (err) {
+    console.error("unsubscribe error", err);
+    state = "error";
+  }
+}
+---
+
+<Layout title="Unsubscribe — Ultraviolet">
+  <Header />
+  <main>
+    <section class="section divider-top">
+      <div class="container" style="max-width: 640px;">
+        <div class="surface" style="padding: 2.5rem;">
+          {
+            state === "done" && (
+              <>
+                <h1 style="margin-bottom: 0.75rem;">You're unsubscribed</h1>
+                <p style="color: var(--ink-2);">
+                  {email} won't receive any more emails from the Ultraviolet
+                  newsletter. You can resubscribe any time from the footer of
+                  our site.
+                </p>
+              </>
+            )
+          }
+          {
+            state === "invalid" && (
+              <>
+                <h1 style="margin-bottom: 0.75rem;">Missing email</h1>
+                <p style="color: var(--ink-2);">
+                  This link is missing an email address, so we can't process an
+                  unsubscribe request.
+                </p>
+              </>
+            )
+          }
+          {
+            state === "error" && (
+              <>
+                <h1 style="margin-bottom: 0.75rem;">Something went wrong</h1>
+                <p style="color: var(--ink-2);">
+                  We couldn't process your unsubscribe request. Please try
+                  again, or email{" "}
+                  <a href="mailto:info@ultraviolet.rs">info@ultraviolet.rs</a>{" "}
+                  and we'll remove you manually.
+                </p>
+              </>
+            )
+          }
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1668,6 +1668,79 @@ details[open] .hdr__msummary::after {
   color: var(--muted);
   font-family: var(--font-mono);
 }
+.ft__nl {
+  margin-bottom: 1.4rem;
+  max-width: 34ch;
+}
+.ft__nl-label {
+  display: block;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  margin-bottom: 0.6rem;
+}
+.ft__nl-row {
+  display: flex;
+  gap: 0.5rem;
+}
+.ft__nl-input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--line-2);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.6rem 0.75rem;
+  outline: none;
+  transition:
+    border-color 0.2s var(--ease),
+    background-color 0.2s var(--ease);
+}
+.ft__nl-input::placeholder {
+  color: var(--muted);
+}
+.ft__nl-input:focus {
+  border-color: var(--accent);
+}
+.ft__nl-hp {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+.ft__nl-btn {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--accent);
+  border: 1px solid transparent;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s var(--ease);
+}
+.ft__nl-btn:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--accent) 86%, #000);
+}
+.ft__nl-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.ft__nl-status {
+  font-size: 0.76rem;
+  color: var(--accent);
+  margin-top: 0.55rem;
+  min-height: 1em;
+}
+.ft__nl-status.is-error {
+  color: #b3453a;
+}
 .ft__cols {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,14 @@
     "MAIL_FROM_EMAIL": "noreply@ultraviolet.rs",
     "SMTP_HOST": "mail.ultraviolet.rs",
     "SMTP_PORT": "465",
-    "SMTP_SECURE": "true"
+    "SMTP_SECURE": "true",
+    "LISTMONK_URL": "https://mailer.absmach.eu",
+    "LISTMONK_LIST_UUID": "5c87fa97-618c-4076-9f57-ea0f1b366029",
+    "LISTMONK_LIST_ID": "4",
+    "LISTMONK_WELCOME_TEMPLATE_ID": "6",
+    "LISTMONK_FROM_EMAIL": "Ultraviolet <info@ultraviolet.rs>",
+    "LISTMONK_TX_API_USER": "uvc-website-tx"
   }
+  // LISTMONK_TX_API_TOKEN is a secret: set locally in .dev.vars, and in prod via
+  // `wrangler secret put LISTMONK_TX_API_TOKEN`.
 }


### PR DESCRIPTION
## Summary
- Adds a newsletter signup form to the footer, backed by a new `/api/subscribe` Astro API route (`export const prerender = false`) that adds the subscriber to a dedicated "Ultraviolet Newsletter" list in listmonk and fires a branded welcome email.
- Adds `/unsubscribe`, a real page rather than an API-only endpoint, since listmonk doesn't provide a working unsubscribe link outside of campaign sends — the welcome email links here instead.
- Routes through a listmonk SMTP server scoped to `info@ultraviolet.rs` and a list-scoped listmonk API user (`uvc-website-tx`), so this stays isolated from other products sharing the same listmonk instance.

## Test plan
- [x] `pnpm check`, `pnpm lint`, `pnpm format:check`, `pnpm build` all pass locally
- [x] Manually subscribed via the footer form in `astro dev` — confirmed the subscriber lands in listmonk and the welcome email send succeeds with no errors
- [x] Manually hit `/unsubscribe` — confirmed the subscriber is removed from the list, and that re-visiting the same link is idempotent
- [x] Verified the `uvc-website-tx` API user cannot see or modify subscribers on other lists in the same listmonk instance
- [ ] Reviewer: confirm the welcome email itself renders correctly in an inbox (SMTP is configured; I only verified the send was accepted, not the rendered result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)